### PR TITLE
Implement fact chains in python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,25 @@ Facts are immutable, so it is not possible to update the ObjectType and FactType
 >>>> dropped_by.add_binding(source_object_type=filename, destination_object_type=hash)
 ```
 
+## Fact Chains
+
+Fact chain is currently a experimental concept, that supports chains of fact, where some of the objects in the chain can unknowns / placeholders.
+
+The unknowns are marked using value "*". And after the chain is created they will get a special value "[placeholder[<HASH>]]", where the HASH is caclulated based on the incoming/outgoing paths from the placeholder.
+
+```
+>>> facts = (
+        c.fact("observedIn").source("uri", "http://uri.no").destination("incident", "*"),
+        c.fact("targets").source("incident", "*").destination("organization", "*"),
+        c.fact("memberOf").source("organization", "*").destination("sector", "energy"),
+    )
+>>> chain = act.fact.fact_chain(*facts)
+>>>> for fact in chain:
+        fact.add()
+```
+
+This feature should be considered experimental and are subject to change. It is implemented client side and the backend does not have the notion of what a fact chain is at the moment, but the frontned will currently show the value in a more user friendly way.
+
 # Tests
 Tests (written in pytest) are contained in the test/ folder. Mock objects are available for most API requests in the test/data/ folder.
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ The unknowns are marked using value "*". And after the chain is created they wil
 
 This feature should be considered experimental and are subject to change. It is implemented client side and the backend does not have the notion of what a fact chain is at the moment, but the frontned will currently show the value in a more user friendly way.
 
+Also note that adding facts in a chain as shown above is NOT atomic, and might lead to inconsistencies if some of the facts does not pass validation in the backend.
+
 # Tests
 Tests (written in pytest) are contained in the test/ folder. Mock objects are available for most API requests in the test/data/ folder.
 

--- a/act/fact.py
+++ b/act/fact.py
@@ -651,7 +651,7 @@ Returns tuple of
             dst_links[dst_str].append([fact_str, src_str])
             src_links[src_str].append([fact_str, dst_str])
 
-        # Add object to known set of known placeholders if is "<>"
+        # Add object to set of known placeholders if value is "<>"
         if fact.source_object.value == "<>":
             placeholders.update((src_str,))
         if fact.destination_object.value == "<>":

--- a/act/fact.py
+++ b/act/fact.py
@@ -641,7 +641,7 @@ Returns tuple of
         dst_links[src_str] = dst_links.get(src_str, []) + [[fact_str, dst_str]]
         src_links[dst_str] = src_links.get(dst_str, []) + [[fact_str, src_str]]
 
-        # For bidiectional bindings, the hops will be in both directions
+        # For bidirectional bindings, the hops will be in both directions
         if fact.bidirectional_binding:
             dst_links[dst_str] = dst_links.get(dst_str, []) + [[fact_str, src_str]]
             src_links[src_str] = src_links.get(src_str, []) + [[fact_str, dst_str]]

--- a/act/fact.py
+++ b/act/fact.py
@@ -645,7 +645,7 @@ Returns tuple of
         if fact.source_object.value != "*" and fact.destination_object.value != "*":
             raise IllegalFactChain(
                 "Fact chain should not include facts without placeholders. " +
-                "Create multiple chains instead and exclude known facts.")
+                "Create multiple chains instead and exclude known facts:\n{}".format(fact))
 
         src_str = str(fact.source_object)
         dst_str = str(fact.destination_object)

--- a/act/fact.py
+++ b/act/fact.py
@@ -1,3 +1,4 @@
+import collections
 import copy
 import hashlib
 import json
@@ -7,7 +8,6 @@ from logging import info, warning
 
 import act
 from act import RE_UUID_MATCH
-import collections
 
 from .base import ActBase, Comment, NameSpace, Organization
 from .obj import Object, ObjectType
@@ -636,9 +636,9 @@ Returns tuple of
     for fact in facts:
         fact_str = fact.type.name
 
+        # String representation of fact
         if fact.value and not fact.value.startswith("-"):
             fact_str += "/{}".format(fact.value)
-
 
         src_str = str(fact.source_object)
         dst_str = str(fact.destination_object)

--- a/act/fact.py
+++ b/act/fact.py
@@ -745,6 +745,6 @@ Returns: facts [Facts]: ACT facts
     for fact in chain:
         for obj in (fact.source_object, fact.destination_object):
             if obj.value == "<>":
-                obj.value = hashes[str(obj)]
+                obj.value = "-{}".format(hashes[str(obj)])
 
     return chain

--- a/act/fact.py
+++ b/act/fact.py
@@ -745,6 +745,6 @@ Returns: facts [Facts]: ACT facts
     for fact in chain:
         for obj in (fact.source_object, fact.destination_object):
             if obj.value == "<>":
-                obj.value = "-{}".format(hashes[str(obj)])
+                obj.value = "<{}>".format(hashes[str(obj)])
 
     return chain

--- a/act/fact.py
+++ b/act/fact.py
@@ -645,7 +645,7 @@ Returns tuple of
         if fact.source_object.value != "*" and fact.destination_object.value != "*":
             raise IllegalFactChain(
                 "Fact chain should not include facts without placeholders. " +
-                "Create multiple chains instead and exlude known facts.")
+                "Create multiple chains instead and exclude known facts.")
 
         src_str = str(fact.source_object)
         dst_str = str(fact.destination_object)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), "rb") as f:
 
 setup(
     name="act-api",
-    version="0.5.0",
+    version="0.5.1",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-python2 -m pytest $*
+#python2 -m pytest $*
 python3 -m pytest $*

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-#python2 -m pytest $*
+python2 -m pytest $*
 python3 -m pytest $*

--- a/test/test_fact.py
+++ b/test/test_fact.py
@@ -263,6 +263,7 @@ def test_fact_chain_ta_incident():
 
     assert len(chain) == 2
 
+    # There should not be any placeholder objects in the chain
     for fact in chain:
         assert not any([fact.source_object.value == "<>", fact.destination_object.value == "<>"])
 

--- a/test/test_fact.py
+++ b/test/test_fact.py
@@ -223,7 +223,7 @@ def test_fact_chain_incident_organization():
     org_seed = act.fact.fact_chain_seed("(organization/<>)", src_links, dst_links)
     incident_seed = act.fact.fact_chain_seed("(incident/<>)", src_links, dst_links)
 
-    seed = "(uri/http://uri.no) -seenIn:-> (incident/<>) -targets:-> (organization/<>) -memberOf:-> (sector/energy)"
+    seed = "(uri/http://uri.no) -[seenIn]-> (incident/<>) -[targets]-> (organization/<>) -[memberOf]-> (sector/energy)"
 
     assert org_seed == seed
     assert incident_seed == seed
@@ -237,6 +237,7 @@ def test_fact_chain_incident_organization():
     # hashes
     for fact in chain:
         assert not any([fact.source_object.value == "<>", fact.destination_object.value == "<>"])
+
 
 def test_fact_chain_ta_incident():
     c = act.Act("", 1)
@@ -256,7 +257,7 @@ def test_fact_chain_ta_incident():
 
     incident_seed = act.fact.fact_chain_seed(list(placeholders)[0], src_links, dst_links)
 
-    assert incident_seed == "(uri/http://uri.no) -seenIn:-> (incident/<>) -attributedTo:-> (threatActor/APT99)"
+    assert incident_seed == "(uri/http://uri.no) -[seenIn]-> (incident/<>) -[attributedTo]-> (threatActor/APT99)"
 
     # Create fact chain
     chain = act.fact.fact_chain(*facts)
@@ -266,6 +267,7 @@ def test_fact_chain_ta_incident():
     # There should not be any placeholder objects in the chain
     for fact in chain:
         assert not any([fact.source_object.value == "<>", fact.destination_object.value == "<>"])
+
 
 def test_fact_chain_incident_tool():
     """Example with multiple incoming links (which should be grouped)"""
@@ -285,5 +287,4 @@ def test_fact_chain_incident_tool():
 
     incident_seed = act.fact.fact_chain_seed("(incident/<>)", src_links, dst_links)
 
-    assert incident_seed == "[(tool/mimikatz) -seenIn:-> ,(uri/http://uri.no) -seenIn:-> ](incident/<>)"
-
+    assert incident_seed == "[(tool/mimikatz) -[seenIn]-> ,(uri/http://uri.no) -[seenIn]-> ](incident/<>)"


### PR DESCRIPTION
This PR implements facts chain in the act python API. 

Fact chains supports placeholder objects (objects with a value of "<>"> which will be replace with a hash created from the seed of incoming / outgoings paths to the placeholder object.

This might need more discussion, but please look at the test first for a starting point.