### PR TITLE
Make act object pickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Facts are immutable, so it is not possible to update the ObjectType and FactType
 ```
 
 # Tests
-Tests (written in pytest) are contained in the test/ folder. Mock objects are available for for most API requests in the test/data/ folder.
+Tests (written in pytest) are contained in the test/ folder. Mock objects are available for most API requests in the test/data/ folder.
 
 This command will execute the tests using both python2 and python3 (requires pytest, python2 and python3).
 ```

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ The unknowns are marked using value "*". And after the chain is created they wil
         c.fact("memberOf").source("organization", "*").destination("sector", "energy"),
     )
 >>> chain = act.fact.fact_chain(*facts)
->>>> for fact in chain:
+>>> for fact in chain:
         fact.add()
 ```
 

--- a/act/schema.py
+++ b/act/schema.py
@@ -215,8 +215,8 @@ class Schema(object):
         return self.data[key]
 
     def __getattr__(self, attr):
-        if attr in self.data:
-            return self.data[attr]
+        if attr in self.__dict__.get("data", {}):
+            return self.__dict__["data"][attr]
 
         raise AttributeError(
             # pylint: disable=too-many-format-args


### PR DESCRIPTION
Make act object pickable to easier support multiprocessing.

Without this fix, __getattr__ will lead to infinite recursion when trying to pickle the object.

[`https://stackoverflow.com/questions/34828857/python-2-getattr-max-recursion-depth`](`https://stackoverflow.com/questions/34828857/python-2-getattr-max-recursion-depth`)