### PR TITLE
Implement __setattr__ on schema and change __getattr__ so schema is pickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Facts are immutable, so it is not possible to update the ObjectType and FactType
 ```
 
 # Tests
-Tests (written in pytest) are contained in the test/ folder. Mock objects are available for for most API requests in the test/data/ folder.
+Tests (written in pytest) are contained in the test/ folder. Mock objects are available for most API requests in the test/data/ folder.
 
 This command will execute the tests using both python2 and python3 (requires pytest, python2 and python3).
 ```

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ The unknowns are marked using value "*". And after the chain is created they wil
         c.fact("memberOf").source("organization", "*").destination("sector", "energy"),
     )
 >>> chain = act.fact.fact_chain(*facts)
->>>> for fact in chain:
+>>> for fact in chain:
         fact.add()
 ```
 

--- a/act/schema.py
+++ b/act/schema.py
@@ -215,8 +215,8 @@ class Schema(object):
         return self.data[key]
 
     def __getattr__(self, attr):
-        if attr in self.data:
-            return self.data[attr]
+        if attr in self.__dict__.get("data", {}):
+            return self.__dict__["data"][attr]
 
         raise AttributeError(
             # pylint: disable=too-many-format-args

--- a/act/schema.py
+++ b/act/schema.py
@@ -234,8 +234,8 @@ class Schema(object):
         # If attribute is in schema, update schema
         if attr in self.__dict__.get("data", {}):
             self.__dict__["data"][attr] = value
-        else:  # If not, set attribute on object
-            super(Schema, self).__setattr__(attr, value)
+        else:  # If not, set attribute on object directly
+            self.__dict__[attr] = value
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/act/schema.py
+++ b/act/schema.py
@@ -215,6 +215,9 @@ class Schema(object):
         return self.data[key]
 
     def __getattr__(self, attr):
+        """
+        Get attribute from schema
+        """
         if attr in self.__dict__.get("data", {}):
             return self.__dict__["data"][attr]
 
@@ -222,6 +225,17 @@ class Schema(object):
             # pylint: disable=too-many-format-args
             "{} object has no attribute {}".format(
                 self.__class__, attr))
+
+    def __setattr__(self, attr, value):
+        """
+        Set schema attribute
+        """
+
+        # If attribute is in schema, update schema
+        if attr in self.__dict__.get("data", {}):
+            self.__dict__["data"][attr] = value
+        else:  # If not, set attribute on object
+            super(Schema, self).__setattr__(attr, value)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), "rb") as f:
 
 setup(
     name="act-api",
-    version="0.5.2",
+    version="0.5.3",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",


### PR DESCRIPTION
- WIthout this change we hit a recursion limit when trying to unpickle a pickled schema  object. This is fixed by referencing self.__dict__["data"] instead of self.data directly
- Also implement __setattr__ so we can change schema attributes directly without changing self.data