### PR TITLE
Modify custom source/destinationObject serializer when adding facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Facts are immutable, so it is not possible to update the ObjectType and FactType
 ```
 
 # Tests
-Tests (written in pytest) are contained in the test/ folder. Mock objects are available for for most API requests in the test/data/ folder.
+Tests (written in pytest) are contained in the test/ folder. Mock objects are available for most API requests in the test/data/ folder.
 
 This command will execute the tests using both python2 and python3 (requires pytest, python2 and python3).
 ```

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ The unknowns are marked using value "*". And after the chain is created they wil
         c.fact("memberOf").source("organization", "*").destination("sector", "energy"),
     )
 >>> chain = act.fact.fact_chain(*facts)
->>>> for fact in chain:
+>>> for fact in chain:
         fact.add()
 ```
 

--- a/act/fact.py
+++ b/act/fact.py
@@ -395,17 +395,16 @@ This is not called directly, but are called from add() if Fact is not a meta fac
         """
         started = time.time()
 
-        # Special serializer for source/destination objects
-        self.data["source_object"] = object_serializer(self.source_object)
-        self.data["destination_object"] = object_serializer(
-            self.destination_object)
-
         params = {
             k: v
             for k, v in self.serialize().items()
             # Exclude inReferenceTo, which is added automatically for retracted facts and meta facts
             if k not in ("inReferenceTo")
         }
+
+        # Special serializer for source/destination objects
+        params["sourceObject"] = object_serializer(self.source_object)
+        params["destinationObject"] = object_serializer(self.destination_object)
 
         fact = self.api_post("v1/fact", **params)["data"]
 

--- a/act/schema.py
+++ b/act/schema.py
@@ -215,8 +215,8 @@ class Schema(object):
         return self.data[key]
 
     def __getattr__(self, attr):
-        if attr in self.data:
-            return self.data[attr]
+        if attr in self.__dict__.get("data", {}):
+            return self.__dict__["data"][attr]
 
         raise AttributeError(
             # pylint: disable=too-many-format-args

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), "rb") as f:
 
 setup(
     name="act-api",
-    version="0.5.2",
+    version="0.5.3",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",


### PR DESCRIPTION
Before this change, we would get invalid data in source/destination objects if we got an error from the backend when adding facts, since data is serialized as "type/value" before it is sent to the backend.

With this change, the data will only be serialized on the parameters sent, and not the internal data structure (self.data).

The parameters are camel cased and not snake cased, since that is handled by the default seriaizer (.serialize()).