### PR TITLE
add support for output_format in handle_fact and make json format standard

### DIFF
--- a/act/helpers.py
+++ b/act/helpers.py
@@ -1,10 +1,10 @@
 import functools
+import ipaddress
 import itertools
 import logging
 import os
 import sys
 import urllib.parse
-import ipaddress
 from logging import warning
 from typing import List
 
@@ -26,7 +26,7 @@ def as_list(value):
 
 
 @functools.lru_cache(4096)
-def handle_fact(fact: Fact) -> None:
+def handle_fact(fact: Fact, output_format="json") -> None:
     """
     add fact if we configured act_baseurl - if not print fact
     This function has a lru cache with size 4096, so duplicates that
@@ -35,7 +35,12 @@ def handle_fact(fact: Fact) -> None:
     if fact.config.act_baseurl:  # type: ignore
         fact.add()
     else:
-        print(fact)
+        if output_format == "json":
+            print(fact.json())
+        elif output_format == "str":
+            print(fact)
+        else:
+            raise act.base.ArgumentError("Illegal output_format: {}".format(output_format))
 
 
 class Act(ActBase):
@@ -426,12 +431,12 @@ Returns created fact type, or exisiting fact type if it already exists.
         return fact_type
 
 
-def handle_uri(actapi: Act, uri: str) -> None:
+def handle_uri(actapi: Act, uri: str, output_format="json") -> None:
     """
     Add all facts (componentOf, scheme, path, basename) from an URI to the platform
     """
     for fact in uri_facts(actapi, uri):
-        handle_fact(fact)
+        handle_fact(fact, output_format=output_format)
 
 
 def uri_facts(actapi: Act, uri: str) -> List[Fact]:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), "rb") as f:
 
 setup(
     name="act-api",
-    version="0.5.3",
+    version="0.5.4",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",


### PR DESCRIPTION

```
>>> import act
>>> c = act.Act("", user_id = None)
>>> f = c.fact("hasLocation").source("asn", "48469").destination("location", "Norway")
>>> act.helpers.handle_fact(f)
{"type": "hasLocation", "value": "", "accessMode": "Public", "sourceObject": {"type": "asn", "value": "48469"}, "destinationObject": {"type": "location", "value": "Norway"}, "bidirectionalBinding": false}
>>> act.helpers.handle_fact(f, output_format="str")
(asn/48469) -[hasLocation]-> (location/Norway)
>>> act.helpers.handle_fact(f, output_format="json")
{"type": "hasLocation", "value": "", "accessMode": "Public", "sourceObject": {"type": "asn", "value": "48469"}, "destinationObject": {"type": "location", "value": "Norway"}, "bidirectionalBinding": false}
>>> act.helpers.handle_fact(f, output_format="ILLEGAL")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/fredrikb/devel/act/act-api-python/act/helpers.py", line 43, in handle_fact
    raise act.base.ArgumentError("Illegal output_format: {}".format(output_format))
act.base.ArgumentError: Illegal output_format: ILLEGAL

>>> act.helpers.handle_uri(c, "http://www.mnemonic.no", output_format="str")
(fqdn/www.mnemonic.no) -[componentOf]-> (uri/http://www.mnemonic.no)
(uri/http://www.mnemonic.no) -[scheme/http]
>>> act.helpers.handle_uri(c, "http://www.mnemonic.no")
{"type": "componentOf", "value": "", "accessMode": "Public", "sourceObject": {"type": "fqdn", "value": "www.mnemonic.no"}, "destinationObject": {"type": "uri", "value": "http://www.mnemonic.no"}, "bidirectionalBinding": false}
{"type": "scheme", "value": "http", "accessMode": "Public", "sourceObject": {"type": "uri", "value": "http://www.mnemonic.no"}, "bidirectionalBinding": false}
```
