### PR TITLE
Require both scheme and address for URIs

### DIFF
--- a/act/api/helpers.py
+++ b/act/api/helpers.py
@@ -478,6 +478,9 @@ Return: List of facts
     addr = my_uri.hostname
     port = my_uri.port
 
+    if not (scheme and addr):
+        raise act.api.base.ValidationError("URI requires both scheme and address part")
+
     try:
         # Is address an ipv4 or ipv6?
         ip = ipaddress.ip_address(addr)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), "rb") as f:
 
 setup(
     name="act-api",
-    version="0.6.6",
+    version="1.0.0",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,6 +1,7 @@
 """ Test for act helpers """
 
-import act
+import pytest
+import act.api
 
 
 def test_add_uri_fqdn() -> None:  # type: ignore
@@ -17,6 +18,20 @@ def test_add_uri_fqdn() -> None:  # type: ignore
     assert api.fact("componentOf").source("path", "/home").destination("uri", uri) in facts
     assert api.fact("scheme", "http").source("uri", uri) in facts
     assert api.fact("basename", "home").source("path", "/home") in facts
+
+
+def test_uri_should_fail() -> None:  # type: ignore
+    """ Test for extraction of facts from uri with ipv4 """
+    api = act.api.Act("", None, "error")
+
+    with pytest.raises(act.api.base.ValidationError):
+        act.api.helpers.uri_facts(api, "http://")
+
+    with pytest.raises(act.api.base.ValidationError):
+        act.api.helpers.uri_facts(api, "www.mnemonic.no")
+
+    with pytest.raises(act.api.base.ValidationError):
+        act.api.helpers.uri_facts(api, "127.0.0.1")
 
 
 def test_add_uri_ipv4() -> None:  # type: ignore


### PR DESCRIPTION
This is breaking change, so we bump version to 1.0.0.