### PR TITLE
added ability for handle_fact to output facts to file handle

### DIFF
--- a/act/api/helpers.py
+++ b/act/api/helpers.py
@@ -6,7 +6,7 @@ import os
 import sys
 import urllib.parse
 from logging import warning
-from typing import List
+from typing import List, TextIO
 
 import act.api
 
@@ -27,19 +27,28 @@ def as_list(value):
 
 
 @functools.lru_cache(4096)
-def handle_fact(fact: Fact, output_format="json") -> None:
+def handle_fact(fact: Fact, output_filehandle: TextIO = None, output_format="json") -> None:
     """
     add fact if we configured act_baseurl - if not print fact
     This function has a lru cache with size 4096, so duplicates that
     occur within this cache will be ignored.
+
+    will use print function if no file handle has been passed, otherwise
+    it will write to the file handle
     """
     if fact.config.act_baseurl:  # type: ignore
         fact.add()
     else:
         if output_format == "json":
-            print(fact.json())
+            if output_filehandle:
+                output_filehandle.write('{}\n'.format(fact.json()))
+            else:
+                print(fact.json())
         elif output_format == "str":
-            print(fact)
+            if output_filehandle:
+                output_filehandle.write('{}\n'.format(str(fact)))
+            else:
+                print(fact)
         else:
             raise act.api.base.ArgumentError("Illegal output_format: {}".format(output_format))
 

--- a/act/api/helpers.py
+++ b/act/api/helpers.py
@@ -27,7 +27,7 @@ def as_list(value):
 
 
 @functools.lru_cache(4096)
-def handle_fact(fact: Fact, output_filehandle: TextIO = None, output_format="json") -> None:
+def handle_fact(fact: Fact, output_format="json", output_filehandle: TextIO = None) -> None:
     """
     add fact if we configured act_baseurl - if not print fact
     This function has a lru cache with size 4096, so duplicates that

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), "rb") as f:
 
 setup(
     name="act-api",
-    version="1.0.1",
+    version="1.0.2",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",


### PR DESCRIPTION
Sometimes it would be great to be able to specify a file handle which handle_fact should output its facts to.