### PR TITLE
Fix documentation for fact chain and support strftime in logfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ The unknowns are marked using value "*". And after the chain is created they wil
         c.fact("targets").source("incident", "*").destination("organization", "*"),
         c.fact("memberOf").source("organization", "*").destination("sector", "energy"),
     )
->>> chain = act.fact.fact_chain(*facts)
+>>> chain = act.api.fact.fact_chain(*facts)
 >>> for fact in chain:
         fact.add()
 ```

--- a/act/api/helpers.py
+++ b/act/api/helpers.py
@@ -80,33 +80,7 @@ class Act(ActBase):
 
         self.configure(Config(act_baseurl, user_id, requests_common_kwargs, origin_name, origin_id))
 
-        self.setup_logging(log_level, log_file, log_prefix)
-
-    def setup_logging(
-            self,
-            log_level="debug",
-            log_file=None,
-            log_prefix="act"):
-        numeric_level = getattr(logging, log_level.upper(), None)
-
-        if not isinstance(numeric_level, int):
-            raise ValueError('Invalid log level: %s' % log_level)
-
-        datefmt = "%Y-%m-%d %H:%M:%S"
-        formatter = "[%(asctime)s] app=" + log_prefix + " level=%(levelname)s msg=%(message)s"
-
-        if log_file:
-            logging.basicConfig(
-                level=numeric_level,
-                filename=log_file,
-                format=formatter,
-                datefmt=datefmt)
-        else:
-            logging.basicConfig(
-                level=numeric_level,
-                stream=sys.stdout,
-                format=formatter,
-                datefmt=datefmt)
+        act.api.utils.setup_logging(log_level, log_file, log_prefix)
 
     # pylint: disable=unused-argument,dangerous-default-value
     def fact_search(

--- a/act/api/utils.py
+++ b/act/api/utils.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import re
+import time
 import act.api
 
 
@@ -17,7 +18,7 @@ def setup_logging(loglevel="debug", logfile=None, prefix="act"):
     if logfile:
         logging.basicConfig(
             level=numeric_level,
-            filename=logfile,
+            filename=time.strftime(logfile),
             format=formatter,
             datefmt=datefmt)
     else:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), "rb") as f:
 
 setup(
     name="act-api",
-    version="1.0.24",
+    version="1.0.25",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",


### PR DESCRIPTION
* fact_chain can be access from act.api, not act (fixed in README.md)
* setup_logging was available both in helpers.py and utils.py. Removed from helpers.py and used the one located in utils.py
* add time.strftime(logfile) when opening the log, so we can use "--logfile uploader-%Y-%m-%d.log" to rotate logs daily