### PR TITLE
change hash algorithm for facts and other object + add tests

### DIFF
--- a/act/api/base.py
+++ b/act/api/base.py
@@ -322,6 +322,9 @@ class Organization(ActBase):
         # otherwize return id or name
         return self.id or self.name or None
 
+    def __hash__(self):
+        return hash(self.name)
+
 
 def origin_serializer(origin):
         # Return None for empty objects (non initialized origins)
@@ -388,6 +391,13 @@ class Origin(ActBase):
 
         info("Deleted origin: {}".format(self.name))
         return self
+
+    def __hash__(self):
+        return hash((
+            self.name,
+            self.namespace,
+            self.organization
+        ))
 
 
 class Comment(ActBase):

--- a/act/api/obj.py
+++ b/act/api/obj.py
@@ -32,6 +32,12 @@ class ObjectType(ActBase):
 
         return self
 
+    def __hash__(self):
+        return hash((
+            self.name,
+            self.namespace
+        ))
+
 
 class ObjectStatistics(ActBase):
     """ObjectStatistics - serialized object specifying statistics"""
@@ -137,6 +143,12 @@ class Object(ActBase):
             return True
 
         return False
+
+    def __hash__(self):
+        return hash((
+            self.type,
+            self.value
+        ))
 
     def __str__(self):
         """

--- a/test/test_fact.py
+++ b/test/test_fact.py
@@ -415,7 +415,7 @@ def test_fact_hash():
     f2 = c2.fact("observedIn").source("uri", "http://uri.no").destination("incident", "my-incident")
     f3 = c.fact("observedIn", origin="dummy").source("uri", "http://uri.no").destination("incident", "my-incident")
 
-    # Hash of two facts with different origin shot not be equal
+    # Hash of two facts with different origin should not be equal
     assert hash(f1) != hash(f2)
 
     # Hash of facts created with origin from default and explitcit added should be equal
@@ -423,7 +423,7 @@ def test_fact_hash():
 
     m1 = f1.meta("observationTime", "1624450340")
 
-    # The hash of the `referenced` object in a meta fact should be equal to the hash
+    # The hash of the `referenced` fact in a meta fact should be equal to the hash
     # of the fact that was used to create the meta fact
     assert hash(m1.in_reference_to) == hash(f1)
 


### PR DESCRIPTION
Update hash for facts / meta facts so all fields that make the fact unique is included.

Also make sure that the hash of the referenced object in a meta fact equals the original fact.

The hash is now calculated exclusively from the name / values and *not* by using the ID. In this way the hash will remain the same whether the fact is added to the platform (and an ID is added) or not.

Another approach could be to use the repr of Fact and ReferencedFact as seed for the hash (maybe even as a default for `__hash__` in schema.py. However, with this we can not make sure the value on `in_reference_to` is the same, because the name of the Classes is not the same (`Fact != ReferencedFact`).