### PR TITLE
Return Meta Fact when retracting fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,13 @@ Use `meta()` to create meta facts (facts about facts).
 >>> import time
 >>> meta = f.meta("observationTime", int(time.time()))
 >>> meta
-Fact(type='observationTime', value=1605100652, in_reference_to=ReferencedFact(type='mentions', id='f994810d-3e4e-4f08-b1c4-a0b67cd1b8fc'), access_mode='RoleBased')
+Fact(type='observationTime', value=1605100652, in_reference_to=Fact(type='mentions', id='f994810d-3e4e-4f08-b1c4-a0b67cd1b8fc'), access_mode='RoleBased')
 ```
 As with facts, the meta fact is not sent to the backend, and you must use `add()` to submit it to the platform.
 
 ```
 >>> meta.add()
-Fact(type='observationTime', value='1605100652', origin=Origin(name='John Doe', id='00000000-0000-0000-0000-000000000001'), confidence=1.0, in_reference_to=ReferencedFact(type='mentions', id='f994810d-3e4e-4f08-b1c4-a0b67cd1b8fc'), organization=Organization(name='Test Organization 1', id='00000000-0000-0000-0000-000000000001'), access_mode='RoleBased')
+MetaFact(type='observationTime', value='1605100652', origin=Origin(name='John Doe', id='00000000-0000-0000-0000-000000000001'), confidence=1.0, in_reference_to=Fact(type='mentions', id='f994810d-3e4e-4f08-b1c4-a0b67cd1b8fc'), organization=Organization(name='Test Organization 1', id='00000000-0000-0000-0000-000000000001'), access_mode='RoleBased')
 ```
 
 ## Get Meta facts

--- a/act/api/base.py
+++ b/act/api/base.py
@@ -322,6 +322,9 @@ class Organization(ActBase):
         # otherwize return id or name
         return self.id or self.name or None
 
+    def __hash__(self):
+        return hash(self.name)
+
 
 def origin_serializer(origin):
         # Return None for empty objects (non initialized origins)
@@ -388,6 +391,13 @@ class Origin(ActBase):
 
         info("Deleted origin: {}".format(self.name))
         return self
+
+    def __hash__(self):
+        return hash((
+            self.name,
+            self.namespace,
+            self.organization
+        ))
 
 
 class Comment(ActBase):

--- a/act/api/base.py
+++ b/act/api/base.py
@@ -1,25 +1,29 @@
-import json
 import copy
-import functools
-from logging import error, info, debug
+import json
 import re
+from logging import error, info
+
 import requests
-from .schema import Schema, Field, schema_doc, MissingField
+
 from . import DEFAULT_ACCESS_MODE
 from .re import UUID_MATCH
+from .schema import Field, MissingField, Schema, schema_doc
 
 
 class NotImplemented(Exception):
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
 
+
 class ArgumentError(Exception):
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
 
+
 class ResponseError(Exception):
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
+
 
 class ValidationError(Exception):
     def __init__(self, *args, **kwargs):
@@ -27,16 +31,16 @@ class ValidationError(Exception):
 
 
 ERROR_HANDLER = {
-        # Mapping of message templates provided in 412 errors from backend to
-        # Exceptions that will be raised
-        "object.not.valid": lambda msg: ValidationError(
-            "{message} ({field}={parameter})".format(**msg)),
-        "organization.not.exist": lambda msg: ValidationError(
-            "{message} ({field}={parameter})".format(**msg))
+    # Mapping of message templates provided in 412 errors from backend to
+    # Exceptions that will be raised
+    "object.not.valid": lambda msg: ValidationError(
+        "{message} ({field}={parameter})".format(**msg)),
+    "organization.not.exist": lambda msg: ValidationError(
+        "{message} ({field}={parameter})".format(**msg))
 }
 
 
-def request(method, user_id, url, requests_common_kwargs = None, **kwargs):
+def request(method, user_id, url, requests_common_kwargs=None, **kwargs):
     """Perform requests towards API
 
 Args:
@@ -185,7 +189,7 @@ class Config(object):
             self,
             act_baseurl,
             user_id,
-            requests_common_kwargs = None,
+            requests_common_kwargs=None,
             origin_name=None,
             origin_id=None,
             access_mode=DEFAULT_ACCESS_MODE,
@@ -296,7 +300,6 @@ class NameSpace(ActBase):
         ))
 
 
-
 class Organization(ActBase):
     """Manage Organization"""
 
@@ -316,12 +319,13 @@ class Organization(ActBase):
         # otherwize return id or name
         return self.id or self.name or None
 
+
 def origin_serializer(origin):
-        # Return None for empty objects (non initialized origins)
-        # otherwize return id or name
-        if not origin:
-            return None
-        return origin.id or origin.name
+    # Return None for empty objects (non initialized origins)
+    # otherwize return id or name
+    if not origin:
+        return None
+    return origin.id or origin.name
 
 
 class Origin(ActBase):
@@ -389,6 +393,7 @@ class Origin(ActBase):
 
         info("Deleted origin: {}".format(self.name))
         return self
+
 
 class Comment(ActBase):
     """Namespace - serialized object specifying Namespace"""

--- a/act/api/fact.py
+++ b/act/api/fact.py
@@ -1,16 +1,16 @@
-import collections
 import copy
 import hashlib
 import json
 import re
 import time
-from logging import info, error, warning
+from logging import error, info, warning
 
 import act.api
 from act.api.re import UUID_MATCH
 
 from . import DEFAULT_VALIDATOR
-from .base import ActBase, Comment, NameSpace, Organization, Origin, origin_serializer
+from .base import (ActBase, Comment, NameSpace, Organization, Origin,
+                   origin_serializer)
 from .obj import Object, ObjectType
 from .schema import Field, MissingField, ValidationError, schema_doc
 
@@ -282,7 +282,6 @@ class AbstractFact(ActBase):
         self.deserialize(**fact)
         return self
 
-
     def set_defaults(self):
         """
             Set fact defaults from config if we have not specified
@@ -308,8 +307,8 @@ class AbstractFact(ActBase):
 
         return self
 
-
     # pylint: disable=unused-argument,dangerous-default-value
+
     def get_acl(self):
         """Get acl"""
 

--- a/act/api/fact.py
+++ b/act/api/fact.py
@@ -394,10 +394,12 @@ Returns retracted fact.
 
         fact = self.api_post(url, **params)["data"]
 
-        self.data = {}
-        self.deserialize(**fact)
+        meta = MetaFact(**fact)
+        # Add config to meta fact (user/auth)
+        meta.configure(self.config)
+        meta.set_defaults()
 
-        return self
+        return meta
 
     def __str__(self):
         """

--- a/act/api/helpers.py
+++ b/act/api/helpers.py
@@ -14,7 +14,7 @@ import act.api
 
 from . import DEFAULT_VALIDATOR
 from .base import ActBase, Config, Origin
-from .fact import Fact, FactType, RelevantFactBindings, RelevantObjectBindings
+from .fact import Fact, MetaFact, FactType, RelevantFactBindings, RelevantObjectBindings
 from .obj import Object, ObjectType
 from .schema import schema_doc
 
@@ -28,7 +28,10 @@ def as_list(value):
 
 
 @functools.lru_cache(maxsize=4096)
-def handle_fact(fact: Fact, output_format="json", output_filehandle: Optional[TextIO] = None) -> None:
+def handle_fact(
+        fact: Fact,
+        output_format="json",
+        output_filehandle: Optional[TextIO] = None) -> Fact:
     """
     add fact if we configured act_baseurl - if not print fact
     This function has a lru cache with size 4096, so duplicates that
@@ -59,6 +62,8 @@ def handle_fact(fact: Fact, output_format="json", output_filehandle: Optional[Te
             output_filehandle.write('{}\n'.format(str(fact_copy)))
         else:
             raise act.api.base.ArgumentError("Illegal output_format: {}".format(output_format))
+
+    return fact_copy
 
 
 class Act(ActBase):
@@ -211,6 +216,16 @@ object and authentication information is passed from the
 act object."""
 
         f = Fact(*args, **kwargs).configure(self.config)
+        f.set_defaults()
+
+        return f
+
+    @schema_doc(Fact.SCHEMA)
+    def meta_fact(self, *args, **kwargs):
+        """Manage meta facts. All arguments are passed to create a MetaFact
+object and authentication information is passed from the act object."""
+
+        f = MetaFact(*args, **kwargs).configure(self.config)
         f.set_defaults()
 
         return f

--- a/act/api/helpers.py
+++ b/act/api/helpers.py
@@ -2,21 +2,21 @@ import copy
 import functools
 import ipaddress
 import itertools
-import logging
 import os
 import sys
-import traceback
 import urllib.parse
-from logging import error, warning
-from typing import List, TextIO, Optional, Text, Tuple
+from logging import warning
+from typing import List, Optional, Text, TextIO, Tuple
 
 import act.api
 
 from . import DEFAULT_VALIDATOR
 from .base import ActBase, Config, Origin
-from .fact import Fact, MetaFact, FactType, RelevantFactBindings, RelevantObjectBindings
+from .fact import (Fact, FactType, MetaFact, RelevantFactBindings,
+                   RelevantObjectBindings)
 from .obj import Object, ObjectType
 from .schema import schema_doc
+
 
 def as_list(value):
     "Encapsulate value in list if value is not already a list/tuple"
@@ -94,8 +94,8 @@ class Act(ActBase):
                 origin_id,
                 access_mode,
                 organization
-                )
             )
+        )
 
         act.api.utils.setup_logging(log_level, log_file, log_prefix)
 
@@ -478,7 +478,11 @@ Returns created fact type, or exisiting fact type if it already exists.
         return fact_type
 
 
-def handle_uri(actapi: Act, uri: str, output_format="json", output_filehandle: Optional[TextIO] = None) -> None:
+def handle_uri(
+        actapi: Act,
+        uri: str,
+        output_format="json",
+        output_filehandle: Optional[TextIO] = None) -> None:
     """Add all facts (componentOf, scheme, path, basename) from an URI to the platform
 
 Raises act.api.base.ValidationError if uri does not have scheme and address component.

--- a/act/api/libs/cli.py
+++ b/act/api/libs/cli.py
@@ -1,0 +1,161 @@
+"""Common worker library"""
+
+import argparse
+import inspect
+import os
+import re
+import sys
+from logging import debug, error
+from typing import Any, Dict, Text, cast
+
+import caep
+
+import act.api
+
+CONFIG_ID = "act"
+CONFIG_NAME = "act.ini"
+
+
+def parseargs(description: str, fact_arguments=False) -> argparse.ArgumentParser:
+    """ Parse arguments """
+    parser = argparse.ArgumentParser(
+        allow_abbrev=False,
+        description="{} ({})".format(description, worker_name()), epilog="""
+
+  --config INI_FILE     Override default locations of ini file
+
+    Arguments can be specified in ini-files, environment variables and
+    as command line arguments, and will be parsed in that order.
+
+    By default, configuration will be read from an ini file in /etc/{1}
+    and ~/.config/{0}/{1} (or in $XDG_CONFIG_DIR if
+    specified).
+
+    Confiuration in "DEFAULT" section will be inherited by each secion.
+
+    It is also possible to use environment variables for configuration.
+    Environment variables should have the argument name in uppercase and
+    "-" replaced with "_".
+
+    E.g. set the CERT_FILE environment variable to configure the
+    --cert-file option.
+
+""".format(CONFIG_ID, CONFIG_NAME), formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument('--http-timeout', type=int, default=120, help="Timeout")
+    parser.add_argument('--proxy-string', help="Proxy to use for external queries")
+    parser.add_argument('--proxy-platform', action="store_true",
+                        help="Use proxy-string towards the ACT platform")
+    parser.add_argument('--cert-file',
+                        help="Cerfiticate to add if you are behind a SSL/TLS interception proxy.")
+    parser.add_argument('--user-id', help="User ID")
+    parser.add_argument('--act-baseurl', help='ACT API URI')
+    parser.add_argument("--logfile", help="Log to file (default = stdout)")
+    parser.add_argument("--loglevel", default="info", help="Loglevel (default = info)")
+    parser.add_argument(
+        '--http-header', help="Comma separated list of HTTP headers, e.g. " +
+        "'HeaderA: val1, HeaderB:comma\\,val2")
+
+    parser.add_argument('--http-user', help="ACT HTTP Basic Auth user")
+    parser.add_argument('--http-password', help="ACT HTTP Basic Auth password")
+
+    if fact_arguments:
+        parser.add_argument("--output-format", dest="output_format", choices=["str", "json"],
+                            default="json", help="Output format for fact (default=json)")
+        parser.add_argument('--access-mode', default=act.api.DEFAULT_ACCESS_MODE,
+                            choices=act.api.ACCESS_MODES,
+                            help="Specify default access mode used for all facts.")
+        parser.add_argument(
+            '--organization', help="Specify default organization applied to all facts.")
+        parser.add_argument('--origin-name', dest='origin_name',
+                            help="Origin name. This name must be defined in the platform")
+        parser.add_argument('--origin-id', dest='origin_id',
+                            help="Origin id. This must be the UUID of the origin in the platform")
+    return parser
+
+
+def __mod_name(stack: inspect.FrameInfo) -> Text:
+    """ Return name of module from a stack ("_" is replaced by "-") """
+    mod = inspect.getmodule(stack[0])
+    return os.path.basename(mod.__file__).replace(".py", "").replace("_", "-")
+
+
+def worker_name() -> Text:
+    """ Return first external module that called this function, directly, or indirectly """
+
+    modules = [__mod_name(stack) for stack in inspect.stack() if __mod_name(stack)]
+    return [name for name in modules if name != modules[0]][0]
+
+
+def handle_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
+    """ Wrapper for caep.handle_args where we set config_id and config_name """
+    args = caep.handle_args(parser, CONFIG_ID, CONFIG_NAME, worker_name())
+
+    if args.http_header:
+        # Convert comma separated list of http headers to dictionary
+        headers = {}
+
+        # Split on comma, unless they are escaped
+        for header in re.split(r'(?<!\\),', args.http_header):
+            if ":" not in header:
+                raise act.api.base.ArgumentError(f"No ':' in header, http header: {header}")
+            header_key, header_val = header.split(":", 1)
+            header_key = header_key.strip().replace("\\,", ",")
+            header_val = header_val.strip().replace("\\,", ",")
+            headers[header_key] = header_val
+        args.http_header = headers
+
+    return cast(argparse.Namespace, args)
+
+
+def fatal(message: Text, exit_code: int = 1) -> None:
+    "Send error to error() and stderr() and exit with exit_code"
+    sys.stderr.write(message.strip() + "\n")
+    error(message.strip())
+    sys.exit(exit_code)
+
+
+def init_act(args: argparse.Namespace) -> act.api.Act:
+    """ Initialize act api from arguments """
+
+    config = {
+        "act_baseurl": args.act_baseurl,
+        "user_id": args.user_id,
+        "log_level": args.loglevel,
+        "log_file": args.logfile,
+        "log_prefix": worker_name(),
+
+        # Provide defaults for optional arguments
+        "origin_name": getattr(args, "origin_name", None),
+        "origin_id": getattr(args, "origin_id", None),
+        "access_mode": getattr(args, "acccess_mode", act.api.DEFAULT_ACCESS_MODE),
+        "organization": getattr(args, "organization", None)
+    }
+
+    requests_kwargs: Dict[Text, Any] = {}
+
+    if args.http_header:
+        requests_kwargs["headers"] = args.http_header
+
+    if args.http_user:
+        requests_kwargs["auth"] = (args.http_user, args.http_password)
+
+    if args.proxy_string and args.proxy_platform:
+        requests_kwargs["proxies"] = {
+            "http": args.proxy_string,
+            "https": args.proxy_string
+        }
+
+    if args.cert_file:
+        requests_kwargs["verify"] = args.cert_file
+
+    config["requests_common_kwargs"] = requests_kwargs
+
+    api = act.api.Act(**config)
+
+    if args.http_header:
+        # Debug output of HTTP headers (must wait until act.api.Act() is initialized
+        # so we have setup logging)
+        debug("HTTP headers: %s", args.http_header)
+
+    return api

--- a/act/api/obj.py
+++ b/act/api/obj.py
@@ -32,6 +32,12 @@ class ObjectType(ActBase):
 
         return self
 
+    def __hash__(self):
+        return hash((
+            self.name,
+            self.namespace
+        ))
+
 
 class ObjectStatistics(ActBase):
     """ObjectStatistics - serialized object specifying statistics"""
@@ -137,6 +143,12 @@ class Object(ActBase):
             return True
 
         return False
+
+    def __hash__(self):
+        return hash((
+            self.type,
+            self.value
+        ))
 
     def __str__(self):
         """

--- a/act/api/obj.py
+++ b/act/api/obj.py
@@ -16,6 +16,13 @@ class ObjectType(ActBase):
         Field("namespace", deserializer=NameSpace),
     ]
 
+    def __hash__(self):
+        return hash((
+            self.__class__.__name__,
+            self.name,
+            self.namespace
+        ))
+
     @schema_doc(SCHEMA)
     def __init__(self, *args, **kwargs):
         super(ObjectType, self).__init__(*args, **kwargs)
@@ -32,12 +39,6 @@ class ObjectType(ActBase):
 
         return self
 
-    def __hash__(self):
-        return hash((
-            self.name,
-            self.namespace
-        ))
-
 
 class ObjectStatistics(ActBase):
     """ObjectStatistics - serialized object specifying statistics"""
@@ -48,6 +49,15 @@ class ObjectStatistics(ActBase):
         Field("last_seen_timestamp", serializer=False),
         Field("last_added_timestamp", serializer=False),
     ]
+
+    def __hash__(self):
+        return hash((
+            self.__class__.__name__,
+            self.type,
+            self.count.
+            self.last_seen_timestamp,
+            self.last_added_timestamp
+        ))
 
 
 class Object(ActBase):
@@ -68,6 +78,14 @@ class Object(ActBase):
         Field("object_type", deserialize_target="type", serializer=False),
         Field("object_value", deserialize_target="value", serializer=False),
     ]
+
+    def __hash__(self):
+        return hash((
+            self.__class__.__name__,
+            self.type,
+            self.value
+        ))
+
 
     @schema_doc(SCHEMA)
     def __init__(self, *args, **kwargs):
@@ -90,18 +108,6 @@ class Object(ActBase):
 
         # Add authentication information to all facts
         return result_set("configure", self.config)
-
-    def __eq__(self, other):
-        """ Check equality with another object """
-
-        # If other is None, return True if id, type and value is None
-        if other is None:
-            if self.id is None and self.type.name is None and self.value is None:
-                return True
-            return False
-
-        # Otherwise, use equality check from super class
-        return super(Object, self).__eq__(other)
 
     def serialize(self):
         # Return None for empty objects (non initialized objects)
@@ -143,12 +149,6 @@ class Object(ActBase):
             return True
 
         return False
-
-    def __hash__(self):
-        return hash((
-            self.type,
-            self.value
-        ))
 
     def __str__(self):
         """

--- a/act/api/obj.py
+++ b/act/api/obj.py
@@ -3,7 +3,7 @@ from logging import info, warning
 import act.api
 
 from . import DEFAULT_VALIDATOR
-from .base import ActBase, NameSpace, ActResultSet, Organization
+from .base import ActBase, ActResultSet, NameSpace
 from .schema import Field, MissingField, schema_doc
 
 
@@ -85,7 +85,6 @@ class Object(ActBase):
             self.type,
             self.value
         ))
-
 
     @schema_doc(SCHEMA)
     def __init__(self, *args, **kwargs):

--- a/act/api/schema.py
+++ b/act/api/schema.py
@@ -1,7 +1,9 @@
 import copy
 import json
-from .utils import snake_to_camel, camel_to_snake
 from logging import info, warning
+
+from .utils import camel_to_snake, snake_to_camel
+
 
 def default_deserializer(value):
     """Default serializer. return trimmed value"""
@@ -246,11 +248,11 @@ class Schema(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return False # Different types -> not equal
+            return False  # Different types -> not equal
 
         for field, value in self.data.items():
             if other.data.get(field) != value:
-                return False # Different field value
+                return False  # Different field value
 
         # All field values are equal
         return True
@@ -275,7 +277,7 @@ class Schema(object):
                 continue
 
             if self.data.get(field.name) == field.default:
-                continue # Exclude default values
+                continue  # Exclude default values
 
             value = self[field.name]
 

--- a/act/api/utils.py
+++ b/act/api/utils.py
@@ -1,7 +1,8 @@
 import logging
-import sys
 import re
+import sys
 import time
+
 import act.api
 
 
@@ -36,6 +37,8 @@ def snake_to_camel(snake):
     return components[0] + "".join([comp.title() for comp in components[1:]])
 
 # https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
+
+
 def camel_to_snake(camel):
     """convert camelCase to snake_case"""
     camel = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', camel)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), "rb") as f:
 
 setup(
     name="act-api",
-    version="1.0.30",
+    version="2.0.0",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",
@@ -19,9 +19,9 @@ setup(
     license="MIT",
     keywords="ACT, mnemonic",
     url="https://github.com/mnemonic-no",
-    packages=["act.api"],
+    packages=["act.api", "act.api.libs"],
     namespace_packages=['act'],
-    install_requires=['requests', 'responses'],
+    install_requires=['caep', 'requests', 'responses'],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/test/act_test.py
+++ b/test/act_test.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+
 def get_mock_data(filename):
     dirname = os.path.dirname(os.path.realpath(__file__))
     with open(os.path.join(dirname, filename), "r") as f:

--- a/test/get_mock_response.py
+++ b/test/get_mock_response.py
@@ -383,13 +383,13 @@ create_mock(
 
 # Create origin
 create_mock(args.act_baseurl,
-    args.user_id,
-    "POST",
-    "v1/origin",
-    json={
-        "name": "my-origin",
-        "description": "My origin",
-        "trust": 0.8
-    },
-    filename="post_v1_origin_myorigin_201.json",
-    )
+            args.user_id,
+            "POST",
+            "v1/origin",
+            json={
+                "name": "my-origin",
+                "description": "My origin",
+                "trust": 0.8
+            },
+            filename="post_v1_origin_myorigin_201.json",
+            )

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,0 +1,36 @@
+
+import pytest
+
+from act.api.base import ActBase, Comment, NameSpace, Organization, Origin
+
+
+class Child(ActBase):
+    pass
+
+
+def test_equailty():
+
+    with pytest.raises(NotImplementedError):
+        assert Child() == Child()
+
+    ns_mnemonic = NameSpace("mnemonic")
+    ns_google = NameSpace("google")
+    org_mnemonic = Organization("mnemonic")
+    org_google = Organization("google")
+    origin_mnemonic = Origin("mnemonic", namespace=ns_mnemonic, organization=org_mnemonic)
+    origin_google = Origin("google", namespace=ns_google, organization=org_google)
+
+    assert ns_mnemonic == NameSpace("mnemonic", "dummy-id")
+    assert ns_mnemonic != ns_google
+    assert org_mnemonic == Organization("mnemonic", "dummy-id")
+    assert org_mnemonic != org_google
+
+    assert origin_mnemonic == Origin(
+        "mnemonic",
+        "dummy-id",
+        namespace=ns_mnemonic,
+        organization=org_mnemonic)
+
+    assert origin_mnemonic != origin_google
+
+    assert Comment("a") == Comment("a")

--- a/test/test_fact.py
+++ b/test/test_fact.py
@@ -5,7 +5,7 @@ import responses
 
 import act
 from act.api.re import TIMESTAMP, TIMESTAMP_MATCH, UUID, UUID_MATCH
-from act.api.fact import Fact, ReferencedFact
+from act.api.fact import Fact
 from act.api.obj import Object
 
 # Organization is required by eval of repr(fact)
@@ -407,7 +407,7 @@ def test_fact_chain_illegal_tool():
         act.api.fact.fact_chain(*facts)
 
 
-def test_fact_hash():
+def test_fact_equality():
     c = act.api.Act("http://localhost:8080", 1)
     c2 = act.api.Act("http://localhost:8080", 1, origin_name="dummy")
 
@@ -417,13 +417,18 @@ def test_fact_hash():
 
     # Hash of two facts with different origin should not be equal
     assert hash(f1) != hash(f2)
+    assert f1 != f2
 
     # Hash of facts created with origin from default and explitcit added should be equal
     assert hash(f2) == hash(f3)
+    assert f2 == f3
 
     m1 = f1.meta("observationTime", "1624450340")
 
     # The hash of the `referenced` fact in a meta fact should be equal to the hash
     # of the fact that was used to create the meta fact
     assert hash(m1.in_reference_to) == hash(f1)
+    assert m1.in_reference_to == f1
 
+    assert act.api.fact.FactType("observedIn") == act.api.fact.FactType("observedIn")
+    assert act.api.fact.FactType("observedIn") == act.api.fact.FactType("observedIn", id="dummy")

--- a/test/test_fact.py
+++ b/test/test_fact.py
@@ -2,15 +2,14 @@ import re
 
 import pytest
 import responses
+from act_test import get_mock_data
 
 import act
-from act.api.re import TIMESTAMP, TIMESTAMP_MATCH, UUID, UUID_MATCH
+# Organization is required by eval of repr(fact)
+from act.api.base import Origin, Organization
 from act.api.fact import Fact
 from act.api.obj import Object
-
-# Organization is required by eval of repr(fact)
-from act.api.base import Organization, Origin
-from act_test import get_mock_data
+from act.api.re import TIMESTAMP, TIMESTAMP_MATCH, UUID, UUID_MATCH
 
 # pylint: disable=no-member
 
@@ -148,7 +147,6 @@ def test_add_fact_validation_error():
     except act.api.base.ValidationError as err:
         assert(str(err) == "Object did not pass validation against ObjectType. " +
                            "(objectValue=127.0.0.x)")
-
 
 
 @responses.activate
@@ -366,7 +364,6 @@ def test_fact_chain_incident_tool():
                             "(uri/http://uri.no) -[observedIn]-> (incident/*)"
 
 
-
 def test_fact_chain_tool_ta():
     """Example with multiple incoming links (which should be grouped)"""
     c = act.api.Act("", 1)
@@ -413,7 +410,8 @@ def test_fact_equality():
 
     f1 = c.fact("observedIn").source("uri", "http://uri.no").destination("incident", "my-incident")
     f2 = c2.fact("observedIn").source("uri", "http://uri.no").destination("incident", "my-incident")
-    f3 = c.fact("observedIn", origin="dummy").source("uri", "http://uri.no").destination("incident", "my-incident")
+    f3 = c.fact("observedIn", origin="dummy").source(
+        "uri", "http://uri.no").destination("incident", "my-incident")
 
     # Hash of two facts with different origin should not be equal
     assert hash(f1) != hash(f2)

--- a/test/test_fact.py
+++ b/test/test_fact.py
@@ -5,7 +5,7 @@ import responses
 
 import act
 from act.api.re import TIMESTAMP, TIMESTAMP_MATCH, UUID, UUID_MATCH
-from act.api.fact import Fact
+from act.api.fact import Fact, ReferencedFact
 from act.api.obj import Object
 
 # Organization is required by eval of repr(fact)
@@ -405,3 +405,25 @@ def test_fact_chain_illegal_tool():
     # Create fact chain
     with pytest.raises(act.api.fact.IllegalFactChain):
         act.api.fact.fact_chain(*facts)
+
+
+def test_fact_hash():
+    c = act.api.Act("http://localhost:8080", 1)
+    c2 = act.api.Act("http://localhost:8080", 1, origin_name="dummy")
+
+    f1 = c.fact("observedIn").source("uri", "http://uri.no").destination("incident", "my-incident")
+    f2 = c2.fact("observedIn").source("uri", "http://uri.no").destination("incident", "my-incident")
+    f3 = c.fact("observedIn", origin="dummy").source("uri", "http://uri.no").destination("incident", "my-incident")
+
+    # Hash of two facts with different origin should not be equal
+    assert hash(f1) != hash(f2)
+
+    # Hash of facts created with origin from default and explitcit added should be equal
+    assert hash(f2) == hash(f3)
+
+    m1 = f1.meta("observationTime", "1624450340")
+
+    # The hash of the `referenced` fact in a meta fact should be equal to the hash
+    # of the fact that was used to create the meta fact
+    assert hash(m1.in_reference_to) == hash(f1)
+

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,6 +1,7 @@
 """ Test for act helpers """
 
 import pytest
+
 import act.api
 
 
@@ -90,7 +91,8 @@ def test_ip_obj() -> None:
 
     api = act.api.Act("", None, "error")
 
-    assert act.api.helpers.ip_obj("2001:67c:21e0::16") == ("ipv6", "2001:067c:21e0:0000:0000:0000:0000:0016")
+    assert act.api.helpers.ip_obj("2001:67c:21e0::16") == (
+        "ipv6", "2001:067c:21e0:0000:0000:0000:0000:0016")
     assert act.api.helpers.ip_obj("::1") == ("ipv6", "0000:0000:0000:0000:0000:0000:0000:0001")
     assert act.api.helpers.ip_obj("127.0.0.1") == ("ipv4", "127.0.0.1")
 
@@ -103,8 +105,8 @@ def test_ip_obj() -> None:
         assert act.api.helpers.ip_obj("300.300.300.300") == ("ipv4", "x.y.x")
 
     assert api.fact("resolvesTo") \
-            .source("fqdn", "localhost") \
-            .destination("ipv4", "127.0.0.1") \
+        .source("fqdn", "localhost") \
+        .destination("ipv4", "127.0.0.1") \
         == api.fact("resolvesTo") \
-            .source("fqdn", "localhost") \
-            .destination(*act.api.helpers.ip_obj("127.0.0.1"))
+        .source("fqdn", "localhost") \
+        .destination(*act.api.helpers.ip_obj("127.0.0.1"))

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -1,9 +1,11 @@
 import re
-import responses
+
 import pytest
-import act
-from act.api.re import UUID_MATCH, UUID
+import responses
 from act_test import get_mock_data
+
+import act
+from act.api.re import UUID, UUID_MATCH
 
 
 # pylint: disable=no-member
@@ -25,6 +27,7 @@ def test_get_object_types():
     # All object types should have a valid uuid
     assert all([re.search(UUID_MATCH, object_t.id)
                 for object_t in object_types])
+
 
 @responses.activate
 def test_create_object_type():
@@ -148,6 +151,7 @@ def test_get_object_search():
     # Should contain both objects and facts
     assert any([isinstance(elem, act.api.obj.Object) for elem in path])
     assert any([isinstance(elem, act.api.fact.Fact) for elem in path])
+
 
 def test_equality():
     c = act.api.Act("http://localhost:8080", 1)

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -148,3 +148,19 @@ def test_get_object_search():
     # Should contain both objects and facts
     assert any([isinstance(elem, act.api.obj.Object) for elem in path])
     assert any([isinstance(elem, act.api.fact.Fact) for elem in path])
+
+def test_equality():
+    c = act.api.Act("http://localhost:8080", 1)
+
+    obj1 = c.object(type="ipv4", value="127.0.0.1")
+    obj2 = c.object(type="ipv4", id="12345678-1234-5678-1234-567812345678", value="127.0.0.1")
+    obj3 = c.object(type="ipv4", value="127.0.0.2")
+
+    assert obj1 == obj2
+    assert obj1 != obj3
+
+    assert act.api.obj.Object("fqdn") == act.api.obj.Object("fqdn")
+
+    # Should be equal even though one of the items has an id
+    assert act.api.obj.Object("fqdn") == act.api.obj.Object("fqdn", id="dummy")
+    assert act.api.obj.Object("fqdn") != act.api.obj.Object("ipv4")

--- a/test/test_origin.py
+++ b/test/test_origin.py
@@ -1,9 +1,10 @@
 import re
+
 import responses
-import pytest
-import act
-from act.api.re import UUID_MATCH, UUID
 from act_test import get_mock_data
+
+import act
+from act.api.re import UUID_MATCH
 
 
 # pylint: disable=no-member

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -1,11 +1,13 @@
-import uuid
 import copy
-import re
 import pickle
 import random
+import re
+import uuid
+
 import pytest
-from act.api.schema import Schema, Field
-from act.api.re import UUID_MATCH, TIMESTAMP_MATCH
+
+from act.api.re import TIMESTAMP_MATCH, UUID_MATCH
+from act.api.schema import Field, Schema
 
 # the Object/Fact and testdata here is a simplified version of the Object/Facts used in ACT
 # The purpose is to only test core functionality of the Schema
@@ -93,6 +95,7 @@ object_test_data = {
     },
     "direction": "FactIsDestination"
 }
+
 
 def __test_data():
     # Generate test data


### PR DESCRIPTION
When retracting a fact, a Meta Fact is returned from the backend.

We need to serialize the resutl as a Meta Fact and return that, instead of a Fact.