### PR TITLE
Return Meta Fact when retracting fact 

### DIFF
--- a/act/api/fact.py
+++ b/act/api/fact.py
@@ -394,10 +394,12 @@ Returns retracted fact.
 
         fact = self.api_post(url, **params)["data"]
 
-        self.data = {}
-        self.deserialize(**fact)
+        meta = MetaFact(**fact)
+        # Add config to meta fact (user/auth)
+        meta.configure(self.config)
+        meta.set_defaults()
 
-        return self
+        return meta
 
     def __str__(self):
         """


### PR DESCRIPTION
When retracting a fact, a Meta Fact is returned from the backend.

We need to serialize the resutl as a Meta Fact and return that, instead of a Fact.