### PR TITLE
Split default validators and add error handler for "fact.not.valid"

### DIFF
--- a/act/api/__init__.py
+++ b/act/api/__init__.py
@@ -9,7 +9,9 @@ FACT_IS_DESTINATION = "FactIsDestination"
 ACCESS_MODES = ["Public", "RoleBased", "Explicit"]
 DEFAULT_ACCESS_MODE = "RoleBased"
 BIDIRECTIONAL_FACT = "BiDirectional"
-DEFAULT_VALIDATOR = r"(.|\n)*"
+DEFAULT_OBJECT_VALIDATOR = r"(.|\n)*"
+DEFAULT_FACT_VALIDATOR = None
+DEFAULT_METAFACT_VALIDATOR = r"(.|\n)*"
 ACT_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 from act.api import utils

--- a/act/api/base.py
+++ b/act/api/base.py
@@ -33,6 +33,9 @@ class ValidationError(Exception):
 ERROR_HANDLER = {
     # Mapping of message templates provided in 412 errors from backend to
     # Exceptions that will be raised
+    "fact.not.valid": lambda msg: ValidationError(
+        "{message} ({field}={parameter})".format(**msg)
+    ),
     "object.not.valid": lambda msg: ValidationError(
         "{message} ({field}={parameter})".format(**msg)
     ),

--- a/act/api/fact.py
+++ b/act/api/fact.py
@@ -8,7 +8,7 @@ from logging import error, info, warning
 import act.api
 from act.api.re import UUID_MATCH
 
-from . import DEFAULT_VALIDATOR
+from . import DEFAULT_FACT_VALIDATOR
 from .base import ActBase, Comment, NameSpace, Organization, Origin, origin_serializer
 from .obj import Object, ObjectType
 from .schema import Field, MissingField, ValidationError, schema_doc
@@ -80,7 +80,7 @@ class FactType(ActBase):
         Field("id"),
         Field("default_confidence"),
         Field("validator", default="RegexValidator"),
-        Field("validator_parameter", default=DEFAULT_VALIDATOR),
+        Field("validator_parameter", default=DEFAULT_FACT_VALIDATOR),
         Field("relevant_object_bindings", deserializer=RelevantObjectBindings),
         Field("relevant_fact_bindings", deserializer=RelevantFactBindings),
         Field("namespace", deserializer=NameSpace),

--- a/act/api/helpers.py
+++ b/act/api/helpers.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Text, TextIO, Tuple
 
 import act.api
 
-from . import DEFAULT_VALIDATOR
+from . import DEFAULT_METAFACT_VALIDATOR, DEFAULT_FACT_VALIDATOR
 from .base import ActBase, Config, Origin
 from .fact import Fact, FactType, MetaFact, RelevantFactBindings, RelevantObjectBindings
 from .obj import Object, ObjectType
@@ -293,7 +293,7 @@ class Act(ActBase):
     def create_fact_type(
         self,
         name,
-        validator=DEFAULT_VALIDATOR,
+        validator=DEFAULT_FACT_VALIDATOR,
         object_bindings=None,
         default_confidence=1.0,
     ):
@@ -305,7 +305,7 @@ Args:
     default_confidence (float):  Default confidence for fact type
 
 Returns created fact type, or exisiting fact type if it already exists.
-""" % DEFAULT_VALIDATOR
+""" % DEFAULT_FACT_VALIDATOR
 
         if not object_bindings:
             object_bindings = []
@@ -379,7 +379,7 @@ Returns created fact type, or exisiting fact type if it already exists.
         return fact_type
 
     def create_fact_type_all_bindings(
-        self, name, validator_parameter=DEFAULT_VALIDATOR, default_confidence=1.0
+        self, name, validator_parameter=DEFAULT_FACT_VALIDATOR, default_confidence=1.0
     ):
         """Create a fact type that can be connected to all object types"""
 
@@ -417,7 +417,7 @@ Returns created fact type, or exisiting fact type if it already exists.
 
         return fact_type
 
-    def create_meta_fact_type(self, name, fact_bindings, validator=DEFAULT_VALIDATOR):
+    def create_meta_fact_type(self, name, fact_bindings, validator=DEFAULT_METAFACT_VALIDATOR):
         """Create meta fact type with given fact bindings
 Args:
     name (str):                  Fact type name
@@ -425,7 +425,7 @@ Args:
     fact_bindings ([]):          List of fact bindings (name)
 
 Returns created fact type, or exisiting fact type if it already exists.
-""" % DEFAULT_VALIDATOR
+""" % DEFAULT_METAFACT_VALIDATOR
 
         existing_fact_types = {
             fact_type.name: fact_type for fact_type in self.get_fact_types()
@@ -460,7 +460,7 @@ Returns created fact type, or exisiting fact type if it already exists.
         return fact_type
 
     def create_meta_fact_type_all_bindings(
-        self, name, validator_parameter=DEFAULT_VALIDATOR
+        self, name, validator_parameter=DEFAULT_METAFACT_VALIDATOR
     ):
         """Create a meta fact type that can be connected to all (non-meta) fact types
 Args:
@@ -468,7 +468,7 @@ Args:
     validator (str):             Regular expression valdiator. Default = %s
 
 Returns created fact type, or exisiting fact type if it already exists.
-""" % DEFAULT_VALIDATOR
+""" % DEFAULT_METAFACT_VALIDATOR
 
         # Get all existing fact types
         existing_fact_types = {

--- a/act/api/obj.py
+++ b/act/api/obj.py
@@ -2,7 +2,7 @@ from logging import info, warning
 
 import act.api
 
-from . import DEFAULT_VALIDATOR
+from . import DEFAULT_OBJECT_VALIDATOR
 from .base import ActBase, ActResultSet, NameSpace
 from .schema import Field, MissingField, schema_doc
 
@@ -12,7 +12,7 @@ class ObjectType(ActBase):
         Field("name"),
         Field("id"),
         Field("validator", default="RegexValidator"),
-        Field("validator_parameter", default=DEFAULT_VALIDATOR),
+        Field("validator_parameter", default=DEFAULT_OBJECT_VALIDATOR),
         Field("namespace", deserializer=NameSpace),
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """Setup script for the python-act library module"""
 
 from os import path
+
 from setuptools import setup
 
 # read the contents of your README file
@@ -10,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="act-api",
-    version="2.0.1",
+    version="2.0.2",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",


### PR DESCRIPTION
Split default valdiators:
* Objects - keep as is
* Meta Fact - keep as is
* Fact - new default is None (do not allow values)

Add error handler for "fact.not.valid" (raise ValidationError)

