### PR TITLE
use null nulldiator if validator is not specified

### DIFF
--- a/act/api/fact.py
+++ b/act/api/fact.py
@@ -97,6 +97,7 @@ class FactType(ActBase):
     def __init__(self, *args, **kwargs):
         super(FactType, self).__init__(*args, **kwargs)
 
+
     def add(self):
         params = self.serialize()
 
@@ -255,7 +256,7 @@ class AbstractFact(ActBase):
         Field(
             "type", deserializer=FactType, serializer=lambda fact_type: fact_type.name
         ),
-        Field("value", default=""),
+        Field("value", default=None),
         Field("id", serializer=False),
         Field("flags", serializer=False),
         Field("origin", deserializer=Origin),
@@ -534,6 +535,12 @@ class Fact(AbstractFact):
         params["sourceObject"] = object_serializer(self.source_object)
         params["destinationObject"] = object_serializer(self.destination_object)
         params["origin"] = origin_serializer(self.origin)
+
+        # Remove "value" parameters if it is empty string or None
+        # This is for backward compatibilty for for output produced on act-api <=v2.0.3 where 
+        # default value is empty string
+        if "value" in params and not params["value"]:
+            del params["value"]
 
         fact = self.api_post("v1/fact", **params)["data"]
 

--- a/act/api/fact.py
+++ b/act/api/fact.py
@@ -536,7 +536,7 @@ class Fact(AbstractFact):
         params["origin"] = origin_serializer(self.origin)
 
         # Replace "" in value parameter with None
-        # This is for backward compatibilty for output produced on act-api <=v2.0.3 where
+        # This is for backward compatibilty for output produced on act-api <=v2.0.3
         # Can be removed when we bump major version to 3.x.x
         if params.get("value") == "":
             warning(

--- a/act/api/fact.py
+++ b/act/api/fact.py
@@ -97,7 +97,6 @@ class FactType(ActBase):
     def __init__(self, *args, **kwargs):
         super(FactType, self).__init__(*args, **kwargs)
 
-
     def add(self):
         params = self.serialize()
 

--- a/act/api/helpers.py
+++ b/act/api/helpers.py
@@ -252,7 +252,15 @@ class Act(ActBase):
         object and authentication information is passed from the
         act object."""
 
-        return FactType(*args, **kwargs).configure(self.config)
+        fact_type = FactType(*args, **kwargs).configure(self.config)
+
+        if not fact_type.validator_parameter:
+            fact_type.validator = "NullValidator"
+
+            # Set to explitcit None (validator_parameter can also be empty string)
+            fact_type.validator_parameter = None
+
+        return fact_type
 
     @schema_doc(ObjectType.SCHEMA)
     def object_type(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="act-api",
-    version="2.0.3",
+    version="2.0.4",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",


### PR DESCRIPTION
* Use `NullValidator` is not validator is specified (None or empty string)
* Use `None` as default value (instead of "")
* Never send "" as value to the platform since that is not allowed if NullValidator is used. Replace with None instead