### PR TITLE
Add support for new style (pydantic) CAEP schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ python-act.tgz
 act_api.egg-info/
 .cache
 .mypy_cache
+.ropeproject

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ The source code for this API is availble on [github](https://github.com/mnemonic
 
 # Changelog
 
+## 2.1.3
+
+* Added support for loading Schema based config in `act.api.lib.cli`, with `load_config()`. The old method of loading the configuration, using `handle_args()` are now deprecated. We will add a deprecation warning in version 2.1.4, and will remove `handle_args()` in version 2.2.0, no earlier than June 1st. 2023.
+
+
 ## 2.1.0
 
 * Support for `indexOption` for Daily/TimeGlobal indices in the platform

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="act-api",
-    version="2.1.2",
+    version="2.1.3",
     author="mnemonic AS",
     author_email="opensource@mnemonic.no",
     description="Python library to connect to the ACT rest API",
@@ -22,7 +22,7 @@ setup(
     url="https://github.com/mnemonic-no",
     packages=["act.api", "act.api.libs"],
     namespace_packages=["act"],
-    install_requires=["caep", "requests", "responses"],
+    install_requires=["caep>=0.1.0", "requests", "responses"],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Keep old implementation as is until we deprecate it.

We can then write new workers to use this new style and port some of the workers if we want to.